### PR TITLE
Fix anonymous authentication to conform to RFC 4505

### DIFF
--- a/txdbus/authentication.py
+++ b/txdbus/authentication.py
@@ -82,6 +82,9 @@ class ClientAuthenticator (object):
         if self.authMech == 'DBUS_COOKIE_SHA1':
             self.sendAuthMessage('AUTH ' + self.authMech + ' ' +
                                  binascii.hexlify(getpass.getuser()))
+        elif self.authMech == 'ANONYMOUS':
+            self.sendAuthMessage('AUTH ' + self.authMech + ' ' +
+                                 binascii.hexlify("txdbus"))
         else:
             self.sendAuthMessage('AUTH ' + self.authMech)
 


### PR DESCRIPTION
The previous spec for anonymous authentication for SASL: RFC 2245
allowed authetication as anonymous without trace data. The current
spec: RFC 4505, does not allow anonymous authentication without
trace data.

We send the library's name as the trace data, which is what libdbus
does (, in addition libdbus also sends the version number). The
trace data could be anything else as well, as long as it is valid
UTF-8 and it must be an email address if it contains '@'.
