### PR TITLE
Preserve traceback on early callRemote failures (e.g. marshaling)

### DIFF
--- a/txdbus/client.py
+++ b/txdbus/client.py
@@ -509,7 +509,7 @@ class DBusClientConnection (txdbus.protocol.BasicDBusProtocol):
 
             return d
         except Exception, e:
-            return defer.fail(e)
+            return defer.fail()
 
 
     def _onMethodTimeout(self, serial, d):


### PR DESCRIPTION
Fairly trivial fix that allows txdbus instead of this hard-to-debug output:

```
2014-03-12 23:10:56 :: twisted ERROR :: Unhandled error in Deferred:
2014-03-12 23:10:56 :: twisted ERROR :: Unhandled Error
Traceback (most recent call last):
Failure: exceptions.IndexError: list index out of range
```

...produce proper tracebacks like this (same exact error):

```
2014-03-12 23:13:56 :: twisted ERROR :: Unhandled error in Deferred:
2014-03-12 23:13:56 :: twisted ERROR :: Unhandled Error
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/twisted/internet/defer.py", line 1237, in unwindGenerator
    return _inlineCallbacks(None, gen, Deferred())
  File "/usr/lib/python2.7/site-packages/twisted/internet/defer.py", line 1099, in _inlineCallbacks
    result = g.send(result)
  File ".../components/nm.py", line 1049, in call
    res = yield obj.callRemote(func, *args, **kws)
  File "/usr/lib/python2.7/site-packages/txdbus/txdbus/objects.py", line 286, in callRemote
    returnSignature  = m.sigOut )
--- <exception caught here> ---
  File "/usr/lib/python2.7/site-packages/txdbus/client.py", line 504, in callRemote
    autoStart    = autoStart )
  File "/usr/lib/python2.7/site-packages/txdbus/message.py", line 190, in __init__
    self._marshal()
  File "/usr/lib/python2.7/site-packages/txdbus/message.py", line 103, in _marshal
    binBody = ''.join( marshal.marshal( self.signature, self.body )[1] )
  File "/usr/lib/python2.7/site-packages/txdbus/marshal.py", line 603, in marshal
    nbytes, vchunks = marshallers[ tcode ]( ct, var, startByte, lendian )
  File "/usr/lib/python2.7/site-packages/txdbus/marshal.py", line 485, in marshal_array
    nbytes, vchunks = marshallers[ tcode ]( tsig, item, start_byte, lendian )
  File "/usr/lib/python2.7/site-packages/txdbus/marshal.py", line 503, in marshal_struct
    return marshal( ct[1:-1], var, start_byte, lendian )
  File "/usr/lib/python2.7/site-packages/txdbus/marshal.py", line 603, in marshal
    nbytes, vchunks = marshallers[ tcode ]( ct, var, startByte, lendian )
  File "/usr/lib/python2.7/site-packages/txdbus/marshal.py", line 485, in marshal_array
    nbytes, vchunks = marshallers[ tcode ]( tsig, item, start_byte, lendian )
  File "/usr/lib/python2.7/site-packages/txdbus/marshal.py", line 503, in marshal_struct
    return marshal( ct[1:-1], var, start_byte, lendian )
  File "/usr/lib/python2.7/site-packages/txdbus/marshal.py", line 603, in marshal
    nbytes, vchunks = marshallers[ tcode ]( ct, var, startByte, lendian )
  File "/usr/lib/python2.7/site-packages/txdbus/marshal.py", line 519, in marshal_variant
    vsig = sigFromPy(var)
  File "/usr/lib/python2.7/site-packages/txdbus/marshal.py", line 247, in sigFromPy
    vtype = type(pobj[0])
exceptions.IndexError: list index out of range
```

Problem is that, from the first traceback, of course, it's pretty much impossible to tell which call failed and what exactly went wrong in that call (in this case - marshal got some bad data in some huge NM connection settings array), while quite easy in the latter case.
