### PR TITLE
- Fixed: Honor sender name when matching signals.

### DIFF
--- a/txdbus/objects.py
+++ b/txdbus/objects.py
@@ -150,7 +150,7 @@ class RemoteDBusObject (object):
                 cb(self, reason)
 
                 
-    def notifyOnSignal(self, signalName, callback, interface=None):
+    def notifyOnSignal(self, signalName, callback, interface=None, sender=None):
         """
         Informs the DBus daemon of the process's interest in the specified
         signal and registers the callback function to be called when the
@@ -202,7 +202,8 @@ class RemoteDBusObject (object):
                                            mtype     = 'signal',
                                            path      = self.objectPath,
                                            member    = signalName,
-                                           interface = iface.name )
+                                           interface = iface.name,
+                                           sender    = sender)
         
         def on_ok( rule_id ):
 

--- a/txdbus/router.py
+++ b/txdbus/router.py
@@ -26,8 +26,8 @@ class Rule (object):
         
 
     def add(self, key, value):
-        #if key in ('mtype', 'sender', 'interface', 'member', 'path', 'destination'):
-        if key in ('mtype', 'interface', 'member', 'path', 'destination'):
+        if key in ('mtype', 'sender', 'interface', 'member', 'path', 'destination'):
+        # if key in ('mtype', 'interface', 'member', 'path', 'destination'):
             self.simple.append( (key, value) )
         else:
             setattr(self, key, value)


### PR DESCRIPTION
In our development we started multiple instances of a process connecting to DBus with distinct busnames, but received the PropertiesChanged Signal on all proxy objects sharing the same path and interface settings.

Exposing the sender parameter to the notifyOnSignal method and re-enabling the sender matching in the router module allowed us to filter the signals properly.
