### PR TITLE
Handle marshalling tuple variant types

### DIFF
--- a/txdbus/marshal.py
+++ b/txdbus/marshal.py
@@ -255,6 +255,9 @@ def sigFromPy( pobj ):
             return 'a' + sigFromPy(pobj[0])
         else:
             return 'av'
+
+    elif isinstance(pobj,       tuple):
+        return '(' + ''.join(sigFromPy(e) for e in pobj) + ')'
     
     elif isinstance(pobj,       dict):
         same = True


### PR DESCRIPTION
The only container types handled are list and dict. This adds support for tuples
as well (aka DBus structs), which are rather simple to introspect.
