### PR TITLE
Add support for bytearrays

### DIFF
--- a/txdbus/marshal.py
+++ b/txdbus/marshal.py
@@ -244,6 +244,7 @@ def sigFromPy( pobj ):
     elif isinstance(pobj, six.integer_types): return 'x'
     elif isinstance(pobj,      float): return 'd'
     elif isinstance(pobj, six.string_types): return 's'
+    elif isinstance(pobj, bytearray): return 'ay'
     
     elif isinstance(pobj,       list):
         vtype = type(pobj[0])
@@ -474,12 +475,12 @@ def marshal_array( ct, var, start_byte, lendian ):
         start_byte += len(initial_padding)
         chunks.append( initial_padding )
 
-    if isinstance(var, (list, tuple)):
+    if isinstance(var, (list, tuple, bytearray)):
         arr_list = var
     elif isinstance(var, dict):
         arr_list = [ tpl for tpl in six.iteritems(var) ]
     else:
-        raise MarshallingError('List, Tuple, or Dictionary required for DBus array. Received: ' + repr(var))
+        raise MarshallingError('List, Tuple, Bytearray, or Dictionary required for DBus array. Received: ' + repr(var))
 
     for item in arr_list:
 

--- a/txdbus/test/test_marshal.py
+++ b/txdbus/test/test_marshal.py
@@ -44,6 +44,9 @@ class SigFromPyTests(unittest.TestCase):
     def test_list(self):
         self.t([1],'ai')
 
+    def test_bytearray(self):
+        self.t(bytearray('\xAA\xAA'), 'ay')
+
     def test_list_multiple_elements_same_type(self):
         self.t([1,2],'ai')
 
@@ -222,6 +225,9 @@ class TestArrayMarshal(TestMarshal):
     def test_byte(self):
         self.check('ay', [[1,2,3,4]], pack('iBBBB', 4, 1,2,3,4))
 
+    def test_byte_bytearray(self):
+        self.check('ay', bytearray('\xaa\xaa'), pack('iBB', 2, 170, 170))
+
     def test_string(self):
         self.check('as', [['x', 'foo']], pack('ii2sxxi4s', 16, 1, b'x', 3, b'foo'))
 
@@ -258,6 +264,9 @@ class TestVariantMarshal(TestMarshal):
                 self.b = 2
 
         self.check('v', [S()], pack('B5sxxii', 4, b'(ii)', 1,2))
+
+    def test_bytearray(self):
+        self.check('v', bytearray('\xAA\xAA'), pack('B2siBB', 2, 'ay', 2, 170, 170))
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Add support for bytearrays with array types.  Also allow for the bytearrays in variant types.

I needed a way to pass in a byte array as a variant type for communicating with wpa supplicant over dbus.
