### PR TITLE
DBus service hangs when you mix both big and small endian dbus clients at the same time

### DIFF
--- a/txdbus/protocol.py
+++ b/txdbus/protocol.py
@@ -110,8 +110,12 @@ class BasicDBusProtocol(protocol.Protocol):
             buffer_len = len(self._buffer)
             
             if self._nextMsgLen == 0 and buffer_len >= 16:
+                # There would be multiple clients using different endians.
+                # Reset endian every time.
                 if self._buffer[:1] != b'l':
                     self._endian = '>'
+                else:
+                    self._endian = '<'
 
                 body_len = struct.unpack(self._endian + 'I', self._buffer[4:8]  )[0]
                 harr_len = struct.unpack(self._endian + 'I', self._buffer[12:16])[0]


### PR DESCRIPTION
I have several dbus client programs that connect to the same dbus server(implemented with txdbus). These client programs are written in different programming languages and I noticed java client uses big endian, and all others use little endian.

Using both big and little endian dbus clients to the same txdbus server cuases dbus service hang.