### PR TITLE
Make sure the rule_id is append to the set for each new signal

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-VERSION     = '1.0.10'
+VERSION     = '1.0.11'
 DESCRIPTION = 'A native Python implementation of the DBus protocol for Twisted applications'
 
 try:

--- a/txdbus/objects.py
+++ b/txdbus/objects.py
@@ -209,7 +209,7 @@ class RemoteDBusObject (object):
             if self._signalRules is None:
                 self._signalRules = set()
                 
-                self._signalRules.add( rule_id )
+            self._signalRules.add( rule_id )
 
             return rule_id
 


### PR DESCRIPTION
Summary : Make sure the rule_id is append to the set for each new signal registered (and not only the first one).


First, I'd like to thank you for your excellent work on txdbus. It's a real pleasure to work with it.

Currently, the rule_id is appended to the set of signalRules of the remote object only for the first signal registered which prevent us to unregister the signal later (using cancelSignalNotification).
With this fix, each successful call to addMatch will result in adding the rule_id to the signalRules set.

Regards,
Gauthier