### PR TITLE
Improve python3 compatibility - allow 'Signals' examples to run.

### DIFF
--- a/txdbus/client.py
+++ b/txdbus/client.py
@@ -19,6 +19,8 @@ import txdbus.protocol
 from txdbus import authentication, message, objects, introspection, router
 from txdbus import error
 
+from txdbus.py3_compat import types
+
 
 # Constant return values for requestBusName
 NAME_ACQUIRED      = 1
@@ -594,7 +596,7 @@ class DBusClientConnection (txdbus.protocol.BasicDBusProtocol):
             e.message = ''
             e.values  = []
             if merr.body:
-                if isinstance(merr.body[0], basestring):
+                if isinstance(merr.body[0], types.anystring):
                     e.message = merr.body[0]
                 e.values = merr.body
             d.errback( e )

--- a/txdbus/interface.py
+++ b/txdbus/interface.py
@@ -7,7 +7,7 @@ model's definition of Interfaces.
 """
 
 from txdbus import marshal
-
+from txdbus.py3_compat import mappings
 
 class Method (object):
     """
@@ -203,7 +203,7 @@ class DBusInterface (object):
             l = list()
             l.append('  <interface name="%s">' % (self.name,))
 
-            k = self.methods.keys()
+            k = mappings.keys(self.methods)
             k.sort()
             for m in ( self.methods[a] for a in k ):
                 l.append('    <method name="%s">' % (m.name,))
@@ -213,7 +213,7 @@ class DBusInterface (object):
                     l.append('      <arg direction="out" type="%s"/>' % (arg_sig,))
                 l.append('    </method>')
 
-            k = self.signals.keys()
+            k = mappings.keys(self.signals)
             k.sort()
             for s in ( self.signals[a] for a in k ):
                 l.append('    <signal name="%s">' % (s.name,))
@@ -221,7 +221,7 @@ class DBusInterface (object):
                     l.append('      <arg type="%s"/>' % (arg_sig,))
                 l.append('    </signal>')
 
-            k = self.properties.keys()
+            k = mappings.keys(self.properties)
             k.sort()
             for p in ( self.properties[a] for a in k ):
                 l.append('    <property name="%s" type="%s" access="%s">' % (p.name, p.sig, p.access,))

--- a/txdbus/objects.py
+++ b/txdbus/objects.py
@@ -11,6 +11,7 @@ from twisted.internet import defer
 from zope.interface import Interface, implementer
 
 from txdbus import interface, error, marshal, message, introspection
+from txdbus.py3_compat import mappings, functions
 
 
 def isSignatureValid( expected, received ):
@@ -403,7 +404,7 @@ class DBusObject (object):
             
                 cache = dict()
 
-                for name, obj in base.__dict__.iteritems():
+                for name, obj in mappings.iteritems(base.__dict__):
                     self._cacheInterfaces( base, cache, name, obj )
 
                 setattr(base, '_dbusIfaceCache', cache)
@@ -419,7 +420,7 @@ class DBusObject (object):
             return cache[ interface_name ]
         
         if inspect.isfunction(obj) and hasattr(obj, '_dbusInterface'):
-            get_ic( obj._dbusInterface ).methods[ obj._dbusMethod ] = getattr(cls, obj.func_name)
+            get_ic( obj._dbusInterface ).methods[ obj._dbusMethod ] = getattr(cls, functions.name(obj))
 
         elif isinstance(obj, DBusProperty):
 
@@ -592,7 +593,7 @@ class DBusObject (object):
                 ifc = cache.get( interfaceName, None )
 
                 if ifc:
-                    for p in ifc.properties.itervalues():
+                    for p in mappings.itervalues(ifc.properties):
                         addp( p )
                     break
 

--- a/txdbus/py3_compat/__init__.py
+++ b/txdbus/py3_compat/__init__.py
@@ -1,0 +1,2 @@
+"""This contains small compatibility functions to make txdbus work in python 2 or 3.
+"""

--- a/txdbus/py3_compat/functions.py
+++ b/txdbus/py3_compat/functions.py
@@ -1,0 +1,7 @@
+"""Compatibility layer for functions.
+"""
+
+def name(function):
+    if hasattr(function, 'func_name'):
+        return function.func_name
+    return function.__name__

--- a/txdbus/py3_compat/mappings.py
+++ b/txdbus/py3_compat/mappings.py
@@ -1,0 +1,24 @@
+"""Python 3 compatibility wrappers for mappings.
+"""
+
+def iteritems(mapping):
+    """mapping.iteritems() in py2, mapping.items() in py3
+    """
+    if hasattr(mapping, 'iteritems'):
+        return mapping.iteritems()
+    return mapping.items()
+
+def itervalues(mapping):
+    """mapping.itervalues() in py2, mapping.values() in py3
+    """
+    if hasattr(mapping, 'itervalues'):
+        return mapping.itervalues()
+    return mapping.values()
+
+def keys(mapping):
+    """mapping.keys(), converted to a list in py3 so things like .sort() work
+    """
+    ks = mapping.keys()
+    if isinstance(ks, list):
+        return ks
+    return list(ks)

--- a/txdbus/py3_compat/types.py
+++ b/txdbus/py3_compat/types.py
@@ -1,0 +1,8 @@
+"""Type adapters for python 3 compatibility.
+"""
+
+import sys
+
+anystring = str
+if sys.version[0] != '3':
+    anystring = basestring


### PR DESCRIPTION
I was using the three examples in the Signals section of
https://pythonhosted.org/txdbus/

Therefore, I have fixed the incompatibilities that were shown up by those examples.

To test with those examples, copy-paste them into text files and run this across each once:

```
2to3 --write script_name
```

I've run the test suites under Python 2.7 to ensure it still works in at least that, and it appears OK but please test again on your machine before merging.