### PR TITLE
Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _trial_temp*
 *\.html
 dist
 MANIFEST
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+sudo: false
+language: python
+cache: pip
+
+python:
+  - 2.6
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
+  - 3.7-dev
+
+env:
+  matrix:
+    - TOXENV=py
+
+matrix:
+  allow_failures:
+    - python: 3.7-dev
+
+install:
+  - pip install tox
+
+script:
+  - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,16 @@
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py26, py27, py33, py34, py35, py36
 
 [testenv]
 commands = python runtests.py
-deps = -r{toxinidir}/requirements.txt
+usedevelop = True
 
 # On Python2.6 "unittest2" is an extra dependency.
-
 [testenv:py26]
 deps = -r{toxinidir}/requirements.txt
     unittest2
+usedevelop = False
 
-[testenv:py33]
-usedevelop = True
-
-[testenv:py34]
-usedevelop = True
+[testenv:py27]
+deps = -r{toxinidir}/requirements.txt
+usedevelop = False


### PR DESCRIPTION
This PR configure travis CI to run for this repo (you still need to go to https://travis-ci.org/profile/cocagne and toggle the switch for this repo). This will help keep an eye on tests passing (especially for PRs) a lot easier.

Right now python2.6 is failing, though I'm inclined to drop support for it -- as well as being *very* old, even the next release of `pip` will drop it.

Regarding python2.7, there's #46, so these are kind of a false-pass, but that's slightly out-of-scope here.

Results for my branch are visible [here](https://travis-ci.org/hobarrera/txdbus/builds/236552193).