### PR TITLE
Really fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 cache: pip
 
 python:
-  - 2.6
   - 2.7
   - 3.3
   - 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ python:
 env:
   matrix:
     - TOXENV=py
+  global:
+    - LOGNAME=travis
 
 matrix:
   allow_failures:

--- a/runtests.py
+++ b/runtests.py
@@ -9,14 +9,16 @@ os.chdir(topdir)
 
 loader = TestLoader()
 
-if sys.version_info[:2] < (3, 0):
+if sys.version_info < (3, 0):
     tests = loader.discover('.', 'test_*.py')
-elif sys.version_info[:2] > (3, 2):
+elif sys.version_info > (3, 2):
     tests = TestSuite()
     tests.addTests(loader.discover('.', 'test_marshal.py'))
     tests.addTests(loader.discover('.', 'test_message.py'))
 else:
     tests = TestSuite()
 
-runner = TextTestRunner(verbosity=1, buffer=True)
-runner.run(tests)
+runner = TextTestRunner(verbosity=2, buffer=True)
+result = runner.run(tests)
+
+sys.exit(not result.wasSuccessful())

--- a/runtests.py
+++ b/runtests.py
@@ -2,11 +2,7 @@
 
 import os
 import sys
-
-if sys.version_info[:2] >= (2,7):
-    from unittest import TestLoader, TextTestRunner, TestSuite
-else:
-    from unittest2 import TestLoader, TextTestRunner, TestSuite
+from unittest import TestLoader, TestSuite, TextTestRunner
 
 topdir = os.path.split(os.path.abspath(__file__))[0]
 os.chdir(topdir)

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 envlist = py27, py33, py34, py35, py36
+skip_missing_interpreters = True
 
 [testenv]
+deps = -rrequirements.txt
 commands = python runtests.py
-usedevelop = True
-
-[testenv:py27]
-deps = -r{toxinidir}/requirements.txt
-usedevelop = False
+passenv =
+  DBUS_SESSION_BUS_ADDRESS
+  USERNAME
+  LOGNAME

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,9 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, py36
+envlist = py27, py33, py34, py35, py36
 
 [testenv]
 commands = python runtests.py
 usedevelop = True
-
-# On Python2.6 "unittest2" is an extra dependency.
-[testenv:py26]
-deps = -r{toxinidir}/requirements.txt
-    unittest2
-usedevelop = False
 
 [testenv:py27]
 deps = -r{toxinidir}/requirements.txt

--- a/txdbus/interface.py
+++ b/txdbus/interface.py
@@ -6,6 +6,8 @@ model's definition of Interfaces.
 @author: Tom Cocagne
 """
 
+import six
+
 from txdbus import marshal
 
 class Method (object):
@@ -202,7 +204,7 @@ class DBusInterface (object):
             l = list()
             l.append('  <interface name="%s">' % (self.name,))
 
-            k = six.iterkeys(self.methods)
+            k = list(six.iterkeys(self.methods))
             k.sort()
             for m in ( self.methods[a] for a in k ):
                 l.append('    <method name="%s">' % (m.name,))
@@ -212,7 +214,7 @@ class DBusInterface (object):
                     l.append('      <arg direction="out" type="%s"/>' % (arg_sig,))
                 l.append('    </method>')
 
-            k = six.iterkeys(self.signals)
+            k = list(six.iterkeys(self.signals))
             k.sort()
             for s in ( self.signals[a] for a in k ):
                 l.append('    <signal name="%s">' % (s.name,))
@@ -220,7 +222,7 @@ class DBusInterface (object):
                     l.append('      <arg type="%s"/>' % (arg_sig,))
                 l.append('    </signal>')
 
-            k = six.iterkeys(self.properties)
+            k = list(six.iterkeys(self.properties))
             k.sort()
             for p in ( self.properties[a] for a in k ):
                 l.append('    <property name="%s" type="%s" access="%s">' % (p.name, p.sig, p.access,))

--- a/txdbus/test/client_tests.py
+++ b/txdbus/test/client_tests.py
@@ -9,8 +9,6 @@
 # an optional mixin class for setting up the internal bus.
 #
 
-from __future__ import print_function
-
 import os
 
 from twisted.internet import reactor, defer


### PR DESCRIPTION
It turns out that some tests were failing for me (on tox and on travis), because they required certain environment variables (and tox isolates the environment by default).

This PR add those, and also alters the `runtests` script to exit non-zero if tests fail (so tox and travis pick that up).

Finally, drop Python 26.