### PR TITLE
Ignore flake8's E741

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [flake8]
+ignore = E741
 exclude=.tox,build,.eggs
 application-import-names=txdbus,tests
 import-order-style=smarkets

--- a/tests/test_marshal.py
+++ b/tests/test_marshal.py
@@ -71,9 +71,9 @@ class SigFromPyTests(unittest.TestCase):
         self.t({'foo': 1, 'bar': '2'}, 'a{sv}')
 
     def test_fail(self):
-        class I(object):
+        class SomeClass(object):
             pass
-        self.assertRaises(m.MarshallingError, m.sigFromPy, I())
+        self.assertRaises(m.MarshallingError, m.sigFromPy, SomeClass())
 
     def test_class(self):
         class V(object):

--- a/tests/test_marshal.py
+++ b/tests/test_marshal.py
@@ -62,13 +62,13 @@ class SigFromPyTests(unittest.TestCase):
         self.t(('foo', 1), '(si)')
 
     def test_dict(self):
-        self.t({'foo': 1},  'a{si}')
+        self.t({'foo': 1}, 'a{si}')
 
     def test_dict_multiple_elements_same_type(self):
-        self.t({'foo': 1, 'bar': 2},  'a{si}')
+        self.t({'foo': 1, 'bar': 2}, 'a{si}')
 
     def test_dict_of_variants(self):
-        self.t({'foo': 1, 'bar': '2'},  'a{sv}')
+        self.t({'foo': 1, 'bar': '2'}, 'a{sv}')
 
     def test_fail(self):
         class I(object):


### PR DESCRIPTION
This kinds triggers false positives, since in our code, these variable names *do* make sense, so let's ignore them.

This unblocks #78