### PR TITLE
Try to avoid race condition when receiving unix fd parameters

### DIFF
--- a/txdbus/protocol.py
+++ b/txdbus/protocol.py
@@ -250,7 +250,12 @@ class BasicDBusProtocol(protocol.Protocol):
         m = message.parseMessage(rawMsg, self._receivedFDs)
         mt = m._messageType
 
-        self._receivedFDs = []
+        # only clear self._receivedFDs when the signature contains a unix fd
+        # helps avoid a race condition where another message can be received
+        # after we receive the unix fd but before the associated unix fd
+        # message is received
+        if m.signature and 'h' in m.signature:
+            self._receivedFDs = []
 
         if mt == 1:
             self.methodCallReceived(m)


### PR DESCRIPTION
When using txdbus with BlueZ, there is a race condition when calling the org.bluez.GattCharacteristic1.AcquireWrite method. After sending the request, we receive an org.freedesktop.dbus.Properties.PropertiesChanged signal. First, txdbus.protocol.BasicDBusProtocol.fileDescriptorReceived is called and stores the unix fd, Then txdbus.protocol.BasicDBusProtocol.rawDBusMessageReceived method is called for the PropertiesChanged signal and clears the cached unix fds. Then the return values of AcquireWrite are receviced and the fd ends up being None.

To work around this, we hang on to the unix fds until we receive a message that has a unix fd as a parameter.