### PR TITLE
replace deprecated inspect API to support type annotations

### DIFF
--- a/txdbus/objects.py
+++ b/txdbus/objects.py
@@ -485,7 +485,11 @@ class DBusObject (object):
         indicating whether or not they accept the \"dbusCaller\" keyword
         argument
         """
-        args = inspect.getargspec(method_obj)[0]
+        try:
+            args = inspect.getfullargspec(method_obj)[0]
+        except:
+            args = inspect.getargspec(method_obj)[0]
+
         needs_caller = False
 
         if len(args) >= 1 and args[-1] == 'dbusCaller':


### PR DESCRIPTION
Inspect's getargspec() has been deprecated and doesn't support type
annotations. If a method is decorated with type hints, the result will
be

Traceback (most recent call last):
Failure: txdbus.error.RemoteError: org.txdbus.PythonException.ValueError: Function has keyword-only parameters or annotations, use inspect.signature() API which can support them

Fixes cocagne/txdbus#80 "ValueError is raised when annotated functions
are used".

Original fix by BrechtDeVlieger.

Signed-off-by: Henrik Lindblom <henrik.lindblom@vaisala.com>