### PR TITLE
Update assertEquals to assertEqual

### DIFF
--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -436,7 +436,7 @@ class AuthTestProtocol(protocol.Protocol):
     def setTest(self, test):
         self.test = test
         self.assertTrue = self.test.assertTrue
-        self.assertEquals = self.test.assertEquals
+        self.assertEqual = self.test.assertEqual
         self.fail = self.test.fail
 
     def succeed(self):


### PR DESCRIPTION
Fixes authentication tests for Python >= 3.12.

See: https://github.com/cocagne/txdbus/issues/95