### PR TITLE
doc: replace deprecated `defer.returnValue()` with `return`

### DIFF
--- a/doc/examples/fd_client.py
+++ b/doc/examples/fd_client.py
@@ -24,7 +24,7 @@ def call_remote_verbose(obj, method, *args, **kwargs):
     print(f'calling {method}{args}', end=' = ')
     result = yield obj.callRemote(method, *args, **kwargs)
     print(repr(result))
-    defer.returnValue(result)
+    return result
 
 
 @defer.inlineCallbacks
@@ -40,7 +40,7 @@ def main(reactor):
         print('obtained remote object')
     except Exception as e:
         print(f'failed obtaining remote object: {e}')
-        defer.returnValue(None)
+        return None
 
     # Open this source file. Ask remote to read it and return byte count.
     with open(__file__, 'rb') as f:

--- a/doc/examples/fd_server.py
+++ b/doc/examples/fd_server.py
@@ -102,7 +102,7 @@ def main(reactor):
     except Exception as e:
         print(f'failed connecting to dbus: {e}')
         reactor.stop()
-        defer.returnValue(None)
+        return None
 
     print('connected to dbus')
     object = FDObject(PATH)

--- a/doc/tutorial.asciidoc
+++ b/doc/tutorial.asciidoc
@@ -49,12 +49,8 @@ operator will be returned from the +yield+ statement. Alternatively, if the
 operation resulted in an exception, the exception will be re-thrown from the
 +yield+ statement.
 
-The return value of functions decorated with +defer.inlineCallbacks+ is a
-deferred. Due to the nature of generator functions, inline callbacks methods
-cannot use the traditional +return+ keyword to return the result of the 
-asynchronous operation. Instead, they must use +defer.returnValue()+ to
-return the result. If +defer.returnValue()+ is not used, the deferred 
-returned by the decorated function will result in +None+
+The return value of functions decorated with +defer.inlineCallbacks+ is
+propagated using +return+ as usual.
 
 .Inline Callbacks Example
 [source,python]
@@ -67,7 +63,7 @@ def checkIPUsage( ip_addr ):
 
     if ip_addr in ip_txt:
         # True will become the result of the Deferred
-        defer.returnValue( True )
+        return True
     else:
         # Will trigger an errback
         raise Exception('IP NOT FOUND')


### PR DESCRIPTION
Fixes #99 

`defer.returnValue()` was required to maintain compatability with Python 2. But today twisted and txdbus only support Python 3. On Python 3, `defer.returnValue()` can be replaced with a standard `return`.

`defer.returnValue()` was deprecated in Twisted 24.7.0