### PR TITLE
CI: bump `checkout` and `setup-python` to use Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
         python-version: ["3.8", "3.9"]
 
     steps:
-      - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v2"
+      - uses: "actions/checkout@v4"
+      - uses: "actions/setup-python@v5"
         with:
           python-version: "${{ matrix.python-version }}"
       - run: sudo apt-get install -y dbus dbus-x11


### PR DESCRIPTION
Resolves issue with using deprecated Node 16.
See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

version 2 (v2) actually uses an older version of Node than 16 (Node 12 which reached EOL in 2022).